### PR TITLE
Install gdml files in build directory

### DIFF
--- a/srcs/CMakeLists.txt
+++ b/srcs/CMakeLists.txt
@@ -65,6 +65,10 @@ foreach(_script ${TBMC_SCRIPTS})
     COPYONLY )
 endforeach()
 
+# Copy the gdml directory to the build directory so that geometry files
+# are available alongside the executable.
+file(COPY ${PROJECT_SOURCE_DIR}/gdml DESTINATION ${PROJECT_BINARY_DIR})
+
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #


### PR DESCRIPTION
## Summary
- copy geometry files when configuring the build so they are available alongside the executable

## Testing
- `cmake ../srcs` *(fails: could not find Geant4)*

------
https://chatgpt.com/codex/tasks/task_e_684b2ad05be4832185d1d350d2805f81